### PR TITLE
Better config errors

### DIFF
--- a/config.go
+++ b/config.go
@@ -9,44 +9,44 @@ import (
 
 const configName string = "config.yml"
 
-func (proxy Proxy) validateHost() (bool, string) {
-  if proxy.Host == "" {
-    return true, "the 'host' field cannot be blank!"
+func validation(condition bool, errorMessage string) string {
+  if condition {
+    return errorMessage
   } else {
-    return false, ""
+    return ""
   }
 }
 
-func (proxy Proxy) validatePort() (bool, string) {
-  if proxy.Port == 0 {
-    return true, "the 'port' field cannot be blank!"
-  } else {
-    return false, ""
-  }
-}
-
-func (proxy Proxy) validateServers() (bool, string) {
-  if len(proxy.Servers) == 0 {
-    return true, "the config must specify at least 1 server"
-  } else {
-    return false, ""
-  }
-}
-
-func (proxy Proxy) validateFields() error {
-  var errors = []string{}
-  var validations = [](func() (bool, string)){
-    proxy.validateHost,
-    proxy.validatePort,
-    proxy.validateServers,
-  }
-
-  for _, validation := range validations {
-    has_error, error_message := validation()
-    if has_error {
-      errors = append(errors, error_message)
+func removeEmpty(errors []string) []string {
+  var filtered = []string{}
+  for _,e := range errors {
+    if e != "" {
+      filtered = append(filtered, e)
     }
   }
+
+  return filtered
+}
+
+func generateValidationErrors(proxy Proxy) []string {
+  return removeEmpty([]string{
+    validation(
+      proxy.Host == "",
+      "the 'host' field cannot be blank",
+    ),
+    validation(
+      proxy.Port == 0,
+      "the 'port' field cannot be blank",
+    ),
+    validation(
+      len(proxy.Servers) == 0,
+      "the config must specify at least 1 server",
+    ),
+  })
+}
+
+func validateFields(proxy Proxy) error {
+  var errors = generateValidationErrors(proxy)
 
   if(len(errors) == 0) {
     return nil
@@ -55,7 +55,7 @@ func (proxy Proxy) validateFields() error {
   }
 }
 
-func readConfig() (Proxy, error) {
+func ReadConfig() (Proxy, error) {
   proxy := Proxy{}
 
   file, err := ioutil.ReadFile(configName)
@@ -68,7 +68,7 @@ func readConfig() (Proxy, error) {
     return proxy, err
   }
 
-  err = proxy.validateFields()
+  err = validateFields(proxy)
   if err != nil {
     return proxy, err
   }

--- a/config.go
+++ b/config.go
@@ -2,14 +2,57 @@ package main
 
 import (
   "fmt"
+  "strings"
   "io/ioutil"
   "gopkg.in/yaml.v2"
 )
 
 const configName string = "config.yml"
 
-func (proxy Proxy) hasRequiredFields() bool {
-  return (proxy.Host != "") && (proxy.Port != 0) && (len(proxy.Servers) != 0)
+func (proxy Proxy) validateHost() (bool, string) {
+  if proxy.Host == "" {
+    return true, "the 'host' field cannot be blank!"
+  } else {
+    return false, ""
+  }
+}
+
+func (proxy Proxy) validatePort() (bool, string) {
+  if proxy.Port == 0 {
+    return true, "the 'port' field cannot be blank!"
+  } else {
+    return false, ""
+  }
+}
+
+func (proxy Proxy) validateServers() (bool, string) {
+  if len(proxy.Servers) == 0 {
+    return true, "the config must specify at least 1 server"
+  } else {
+    return false, ""
+  }
+}
+
+func (proxy Proxy) validateFields() error {
+  var errors = []string{}
+  var validations = [](func() (bool, string)){
+    proxy.validateHost,
+    proxy.validatePort,
+    proxy.validateServers,
+  }
+
+  for _, validation := range validations {
+    has_error, error_message := validation()
+    if has_error {
+      errors = append(errors, error_message)
+    }
+  }
+
+  if(len(errors) == 0) {
+    return nil
+  } else {
+    return fmt.Errorf(strings.Join(errors, ", "))
+  }
 }
 
 func readConfig() (Proxy, error) {
@@ -25,9 +68,9 @@ func readConfig() (Proxy, error) {
     return proxy, err
   }
 
-  if !proxy.hasRequiredFields() {
-    // TODO: The error should say what fields are missing
-    return proxy, fmt.Errorf("Missing required fields in config")
+  err = proxy.validateFields()
+  if err != nil {
+    return proxy, err
   }
 
   return proxy, nil

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 func main() {
     LogInfo("Spinning up load balancer...")
     LogInfo("Reading Config.yml...")
-    proxy, err := readConfig()
+    proxy, err := ReadConfig()
     if err != nil {
       LogErr("An error occurred while trying to parse config.yml")
       LogErrAndCrash(err.Error())

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ func main() {
     LogInfo("Reading Config.yml...")
     proxy, err := readConfig()
     if err != nil {
-      LogErr("Failed to read config.yml")
+      LogErr("An error occurred while trying to parse config.yml")
       LogErrAndCrash(err.Error())
     }
 


### PR DESCRIPTION
Closes #2 

We now throw an error that says exactly what in the config parsing failed. Also DRYd up a bunch of code and made it way easier to add new validations in the future. This can probably be improved even more.